### PR TITLE
STM32 MP3 Control Added

### DIFF
--- a/STM32/Core/Inc/mp3.h
+++ b/STM32/Core/Inc/mp3.h
@@ -1,0 +1,31 @@
+#ifndef DFPLAYER_H
+#define DFPLAYER_H
+
+#include "stm32l0xx_hal.h"
+#include "lcd.h"
+
+// Send Command to DFPlayer Mini 
+void mp3SendCommand(uint8_t cmd, uint8_t param1, uint8_t param2);
+// Play MP3 track 
+void mp3Play(uint8_t trackNum);
+// Volume Set (0 ~ 30)
+void mp3SetVolume(uint8_t level);
+// Volume Increase (+5)
+void mp3IncreaseVolume(void);
+// Volume Decrease (-5)
+void mp3DecreaseVolume(void);
+// DFPlayer Mini Reset
+void mp3DfplayerInit(void);
+// Stop Playing mp3
+void mp3Stop(void);
+// Resume Playing mp3
+void mp3Resume(void);
+// Next Track
+void mp3Next(void);
+// Previous Track
+void mp3Previous(void);
+// Get Random Number
+uint8_t mp3GetRandomTrack(void);
+// System Time
+void mp3InitRandomSeed(void);
+#endif /* DFPLAYER_H */

--- a/STM32/Core/Src/mp3.c
+++ b/STM32/Core/Src/mp3.c
@@ -1,0 +1,149 @@
+#include "mp3.h"
+#include <stdlib.h>
+
+// UART Handler
+extern UART_HandleTypeDef huart1;
+extern UART_HandleTypeDef huart4;
+
+// Current Volume
+extern uint8_t currentVolume;
+extern uint8_t currentTrack;
+extern uint8_t receivedTrack;
+extern uint8_t receivedNum;
+extern uint8_t stopTrack;
+
+// Send Command to DFPlayer Mini 
+void mp3SendCommand(uint8_t cmd, uint8_t param1, uint8_t param2) {
+	uint8_t command[10] = {0x7E, 0xFF, 0x06, cmd, 0x00, param1, param2, 0x00, 0x00, 0xEF};
+  uint16_t checksum = -(command[1] + command[2] + command[3] + command[4] + command[5] + command[6]);
+
+  command[7] = (checksum >> 8) & 0xFF;
+  command[8] = checksum & 0xFF;
+
+  HAL_UART_Transmit(&huart4, command, 10, HAL_MAX_DELAY);
+}
+
+// Play MP3 track 
+void mp3Play(uint8_t trackNum) {
+	// lcdClearDisplay();
+	if (trackNum >= 1 && trackNum <= 8) {
+		currentTrack = trackNum;
+		mp3SendCommand(0x03, 0x00, currentTrack);
+		
+		/*lcdSetCursor(0,0); // Line 1
+		char buffer1[16];
+		sprintf(buffer1, "Music Track: %d", currentTrack);
+		lcdSendString(buffer1);
+		
+		lcdSetCursor(1,0); // Line 2
+		char buffer2[16];
+		sprintf(buffer2, "Volume: %d", currentVolume);
+		lcdSendString(buffer2);*/
+	}
+	/*else {
+		lcdSetCursor(0,0); // Line 1
+		char buffer[16];
+		sprintf(buffer, "Invalid Track");
+		lcdSendString(buffer);
+	}*/
+}
+
+// Volume Set (0 ~ 30)
+void mp3SetVolume(uint8_t level) {
+	if (level > 30) level = 30;
+	currentVolume = level;
+	mp3SendCommand(0x06, 0x00, currentVolume);
+}
+
+// Volume Increase (+5)
+void mp3IncreaseVolume(void) {
+	if (currentVolume + 5 <= 30) currentVolume += 5;
+	else currentVolume = 30;
+	mp3SendCommand(0x06, 0x00, currentVolume);
+	
+	/*lcdClearDisplay();
+	lcdSetCursor(0,0); // Line 1
+	char buffer1[16];
+	sprintf(buffer1, "Volume: %d", currentVolume);
+	lcdSendString(buffer1);
+	
+	if (currentVolume == 30) {
+		lcdSetCursor(1,0); // Line 2
+		char buffer2[16];
+		sprintf(buffer2, "Volume Max");
+		lcdSendString(buffer2);
+	}*/
+}
+
+// Volume Decrease (-5)
+void mp3DecreaseVolume(void) {
+	if (currentVolume - 5 >= 0) currentVolume -= 5;
+	else currentVolume = 0;
+	mp3SendCommand(0x06, 0x00, currentVolume);
+	
+	/*lcdClearDisplay();
+	lcdSetCursor(0,0); // Line 1
+	char buffer1[16];
+	sprintf(buffer1, "Volume: %d", currentVolume);
+	lcdSendString(buffer1);
+	
+	if (currentVolume == 0) {
+		lcdSetCursor(1,0); // Line 2
+		char buffer2[16];
+		sprintf(buffer2, "Volume Min");
+		lcdSendString(buffer2);
+	}*/
+}
+
+// DFPlayer Mini Reset
+void mp3DfplayerInit(void) {
+  mp3SendCommand(0x3F, 0x00, 0x00);
+  mp3SetVolume(15);
+}
+
+// Stop Playing mp3
+void mp3Stop(void) {
+	stopTrack = currentTrack;
+  mp3SendCommand(0x16, 0x00, 0x00);  // Stop
+	
+	/*lcdClearDisplay();
+	lcdSetCursor(0,0); // Line 1
+	char buffer1[16];
+	sprintf(buffer1, "Music Stop");
+	lcdSendString(buffer1);*/
+}
+
+// Resume Playing mp3
+void mp3Resume(void) {
+  mp3SendCommand(0x0D, 0x00, 0x00);  // Resume
+	
+	/*lcdClearDisplay();
+	lcdSetCursor(0,0); // Line 1
+	char buffer1[16];
+	sprintf(buffer1, "Resume");
+	lcdSendString(buffer1);*/
+}
+
+// Play Next Track
+void mp3Next(void) {
+	if (currentTrack < 8) {
+		mp3Play(currentTrack + 1);
+	}
+}
+
+// Play Previous Track
+void mp3Previous(void) {
+  if (currentTrack > 1) {
+		mp3Play(currentTrack - 1);
+	}
+}
+
+// Get Random Number
+uint8_t mp3GetRandomTrack(void) {
+    return (rand() % 8) + 1;  // 1 ~ 8
+}
+
+// System Time
+void mp3InitRandomSeed(void) {
+    srand(HAL_GetTick());
+}


### PR DESCRIPTION
🎵 DFPlayer Mini – STM32 UART 제어
📁 프로젝트 개요
DFPlayer Mini MP3 모듈을 UART4를 통해 제어

ESP32에서 UART로 트랙 번호를 전송하면 STM32가 이를 해석해 DFPlayer Mini로 해당 명령을 전달

⚙️ 주요 기능
| 기능 | 설명 | DFPlayer 명령어 |

| playMP3(n) | n번 트랙 재생 (18) | 0x03 |
| mp3Stop() | 재생 중지 | 0x16 |
| mp3Resume() | 멈춘 트랙 00:00부터 재생 | 0x0D |
| mp3Next() | 다음 트랙 재생 | 0x01 |
| mp3Previous() | 이전 트랙 재생 | 0x02 |
| mp3SetVolume(n) | 볼륨 설정 (030) | 0x06 |
| mp3IncreaseVolume() | 볼륨 +5 증가 | 0x06 |
| mp3DecreaseVolume() | 볼륨 -5 감소 | 0x06 |
| mp3GetRandomTrack() | 1~8 랜덤 정수 반환 | |
| mp3InitRandomSeed() | 난수 생성 | |

🧩 mp3SendCommand 함수
void mp3SendCommand(uint8_t cmd, uint8_t param1, uint8_t param2) {
    uint8_t command[10] = {0x7E, 0xFF, 0x06, cmd, 0x00, param1, param2, 0x00, 0x00, 0xEF};
    uint16_t checksum = -(command[1] + command[2] + command[3] + command[4] + command[5] + command[6]);
    command[7] = (checksum >> 8) & 0xFF;
    command[8] = checksum & 0xFF;
    HAL_UART_Transmit(&huart4, command, 10, HAL_MAX_DELAY);
}

명령 프레임(command[10]) 생성 - CheckSum 계산 - UART 전송

📦 트랙 파일 구성
## SD Card Structure

/mp3/0001.mp3
~
/mp3/0008.mp3

⚠️ 음원 형식은 반드시 4자리 숫자 형식 (ex. 0001.mp3)이어야 함
⚠️ SD Card는 최대 32GB